### PR TITLE
refactor(response): chunked and streaming support

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -2,11 +2,13 @@ package server
 
 import (
 	"fmt"
+	"io"
 	"mime"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Abb133Se/httpServer/internal/utils"
 )
@@ -219,6 +221,24 @@ func handleUserByID(req *Request) Response {
 		Reason:  "OK",
 		Headers: map[string]string{"Content-Type": "text/plain"},
 		Body:    []byte(fmt.Sprintf("Matched user path: %s", req.Path)),
+	}
+}
+
+func handleStream(req *Request) Response {
+	utils.Info("Starting streaming response")
+
+	return Response{
+		Version: "HTTP/1.1",
+		Status:  200,
+		Reason:  "OK",
+		Headers: map[string]string{"Content-Type": "text/plain"},
+		StreamFunc: func(w io.Writer) error {
+			for i := 1; i <= 10; i++ {
+				fmt.Fprintf(w, "Chunk %d\n", i)
+				time.Sleep(1 * time.Second)
+			}
+			return nil
+		},
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -81,6 +81,8 @@ func setupRoutes(router *Router) {
 
 	router.HandleRegex(`^/user/\d+$`, handleUserByID)
 
+	router.Handle("/stream", "GET", handleStream)
+
 	utils.Info("All routes registered successfully")
 }
 


### PR DESCRIPTION
Implemented support for chunked transfer encoding and streaming responses.
- Added StreamFunc to Response struct for on-demand data writing.
- Updated SendResponse to handle chunked and streamed data.
- Added ChunkedWriter helper for compliant chunked encoding.
- Introduced example streaming handler to demonstrate live data output. Enhances server compliance with HTTP/1.1 standards and enables efficient handling of large or continuous responses.